### PR TITLE
Feature/new text edit scene

### DIFF
--- a/src_app/test_scenes/sceneTextEdit.js
+++ b/src_app/test_scenes/sceneTextEdit.js
@@ -4,14 +4,34 @@ class SceneTextEdit extends React.Component {
   render () {
     return (
       <view localPosition={this.props.localPosition}>
-        <text localPosition={[-0.3, 0.45, 0]} textSize={0.05}>Default</text>
-        <textEdit localPosition={[-0.3, 0.425, 0]} width={0.7} height={0.05} hint={'Placeholder'} text={' '}></textEdit>
+        <text localPosition={[-0.3, 0.45, 0]} textSize={0.05}>Username</text>
+        <textEdit localPosition={[-0.3, 0.4, 0]} 
+            width={0.7} 
+            height={0.07} 
+            textSize={0.05}
+            hint={'Username'} 
+            textAlignment={'center'}
+            fontParams={{weight: "bold", style: "normal" }}
+            textColor={[0, 1, 0, 1]}/>
 
-        <text localPosition={[-0.3, 0.25, 0]} textSize={0.05}>Password</text>
-        <textEdit localPosition={[-0.3, 0.225, 0]} width={0.7} height={0.05} password> </textEdit>
+        <text localPosition={[-0.3, 0.3, 0]} textSize={0.05}>Password</text>
+        <textEdit localPosition={[-0.3, 0.25, 0]} width={0.7} height={0.07} textAlignment={'center'} textSize={0.05} hint={'Password'} hintColor={[1, 0, 0, 1]} password></textEdit>
 
-        <text localPosition={[-0.3, 0.05, 0]} textSize={0.05}>Multiline</text>
-        <textEdit localPosition={[-0.3, 0.025, 0]} width={0.7} height={0.25} multiline>Multiline text edit</textEdit>
+        <text localPosition={[-0.3, 0.1, 0]} textSize={0.05}>E-mail</text>
+        <textEdit localPosition={[-0.3, 0.05, 0]} width={0.7} height={0.05} textEntry={"email"} hint={''}></textEdit>
+
+        <text localPosition={[-0.3, -0.05, 0]} textSize={0.05}>Phone number</text>
+        <textEdit localPosition={[-0.3, -0.1, 0]} width={0.7} height={0.05} textEntry={"numeric"} text={'0048'} charLimit={15} charSpacing={0.1}></textEdit>
+
+        <text localPosition={[-0.3, -0.2, 0]} textSize={0.05}>Additional info</text>
+        <textEdit localPosition={[-0.3, -0.25, 0]} 
+            scrolling={true} 
+            textPadding={[0.03, 0.03, 0.03, 0.03]}
+            fontParams={{weight: "light", style: "italic" }} 
+            width={0.7} 
+            height={0.25} 
+            hint={'*optional'}
+            multiline/>
       </view>
     );
   }


### PR DESCRIPTION
Testing new properties for text edit node. Note that hintColor property is not implemented yet on android, so hint color for password on the screenshot is incorrect.

![text1](https://user-images.githubusercontent.com/15632654/65767749-1693ac80-e12f-11e9-8908-88f99bcbc4c7.png)
![text2](https://user-images.githubusercontent.com/15632654/65767750-172c4300-e12f-11e9-8264-63a295a56cc6.png)

