### PR TITLE
fixed deeplinks crash on ml1

### DIFF
--- a/global/globalVariables.js
+++ b/global/globalVariables.js
@@ -1,6 +1,6 @@
 var initialDeeplink = undefined
 
-deeplinkSet = () => undefined
+export var deeplinkSet = () => undefined
 
 export function registerOnDeeplinkSet(onDeeplinkSet) {
     deeplinkSet = onDeeplinkSet


### PR DESCRIPTION
```
 Uncaught ReferenceError: deeplinkSet is not defined: bin/global/global
```